### PR TITLE
Fix leak in generate_btf

### DIFF
--- a/btfgen.c
+++ b/btfgen.c
@@ -118,6 +118,8 @@ int generate_btf(const char *src_btf, const char *dst_btf, const char *objspaths
 	}
 
 out:
+	if (!libbpf_get_error(btf_new))
+		btf__free(btf_new);
 	bpf_reloc_info_free(reloc_info);
 	return err;
 }


### PR DESCRIPTION
# Fix leak in generate_btf

Fix a leak that happens when `generate_btf`.

The leak can be observed when `generate_btf` is called thousands of times, it will present a linear growth in memory.

![image](https://user-images.githubusercontent.com/3083633/137766961-2dcadb9b-6505-4c63-bc70-6758956821f2.png)


After this fix, memory usage is stable.

![image](https://user-images.githubusercontent.com/3083633/137767318-d3bd23ea-98a1-4d0e-91e0-abbedb5fe3d3.png)




## How to use

Same as before, this is just a fix

## Testing done

Tested against a single program, `execsnoop.bpf.o` from BCC and against many duplicated BTF files.
For simplicity, one could also add a `while(1)` when `generate_btf` is called to trigger the behavior.