### PR TITLE
fix btfgen for the latest libbpf patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ libbpf_out/usr/lib64/libbpf.a: $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Mak
 		$(MAKE) DESTDIR=$(BASEDIR)/libbpf_out install_uapi_headers && \
 		cd ../..
 
-btfgen: btfgen.c libbpf_out/usr/lib64/libbpf.a
+btfgen: main.c btfgen.c libbpf_out/usr/lib64/libbpf.a
 	$(CC) -g -static -ggdb -gdwarf -O2 -o btfgen $(INCLUDES) $^ -lelf -lz
 
 clean:

--- a/btfgen.c
+++ b/btfgen.c
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <argp.h>
-#include <dirent.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/resource.h>
@@ -22,164 +21,547 @@
 #include <bpf/libbpf.h>
 #include <bpf/btf.h>
 
-#define OBJ_KEY 260
-#define MAX_OBJECTS 128
+#include "btfgen.h"
+#include "hashmap.h"
 
-struct env {
-	const char *outputdir;
-	const char *inputdir;
-	const char *obj[MAX_OBJECTS];
-	int obj_index;
-	bool verbose;
-};
+#include "stolen.h"
 
-static const struct argp_option opts[] = {
-	{ "verbose", 'v', NULL, 0, "display libbpf debug messages" },
-	{ "outputdir", 'o', "outputdir", 0, "dir to output the result BTF files" },
-	{ "inputdir", 'i', "inputdir", 0, "dir with source BTF files to use" },
-	{ "object", OBJ_KEY,  "object", 0, "path of object file to generate BTFs for" },
-	{},
-};
-
-static error_t parse_arg(int key, char *arg, struct argp_state *state)
+static inline __u32 btf_type_info(int kind, int vlen, int kflag)
 {
-	struct env *env = state->input;
-	switch (key) {
-	case 'v':
-		env->verbose = true;
-		break;
-	case 'o':
-		env->outputdir = arg;
-		break;
-	case 'i':
-		env->inputdir = arg;
-		break;
-	case OBJ_KEY:
-		env->obj[env->obj_index++] = arg;
-		break;
-	case ARGP_KEY_END:
-		if (env->outputdir == NULL || env->inputdir == NULL || env->obj_index == 0)
-			argp_usage(state);
-		break;
+	return (kflag << 31) | (kind << 24) | vlen;
+}
+
+static bool core_relo_is_field_based(enum bpf_core_relo_kind kind)
+{
+	switch (kind) {
+	case BPF_FIELD_BYTE_OFFSET:
+	case BPF_FIELD_BYTE_SIZE:
+	case BPF_FIELD_EXISTS:
+	case BPF_FIELD_SIGNED:
+	case BPF_FIELD_LSHIFT_U64:
+	case BPF_FIELD_RSHIFT_U64:
+		return true;
 	default:
-		return ARGP_ERR_UNKNOWN;
+		return false;
 	}
+}
+
+static bool core_relo_is_type_based(enum bpf_core_relo_kind kind)
+{
+	switch (kind) {
+	case BPF_TYPE_ID_LOCAL:
+	case BPF_TYPE_ID_TARGET:
+	case BPF_TYPE_EXISTS:
+	case BPF_TYPE_SIZE:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool core_relo_is_enumval_based(enum bpf_core_relo_kind kind)
+{
+	switch (kind) {
+	case BPF_ENUMVAL_EXISTS:
+	case BPF_ENUMVAL_VALUE:
+		return true;
+	default:
+		return false;
+	}
+}
+
+struct btf_reloc_member {
+	struct btf_member *member;
+	int idx;
+};
+
+struct btf_reloc_type {
+	struct btf_type *type;
+	unsigned int id;
+
+	struct hashmap *members;
+};
+
+struct btf_reloc_info {
+	struct hashmap *types;
+	struct hashmap *ids_map;
+
+	struct btf *src_btf;
+};
+
+static size_t bpf_reloc_info_hash_fn(const void *key, void *ctx)
+{
+	return (size_t)key;
+}
+
+static bool bpf_reloc_info_equal_fn(const void *k1, const void *k2, void *ctx)
+{
+	return k1 == k2;
+}
+
+static void *uint_as_hash_key(int x) {
+	return (void *)(uintptr_t)x;
+}
+
+void bpf_reloc_type_free(struct btf_reloc_type *type) {
+	struct hashmap_entry *entry;
+	int i;
+
+	if (IS_ERR_OR_NULL(type))
+		return;
+
+	if (!IS_ERR_OR_NULL(type->members)) {
+		hashmap__for_each_entry(type->members, entry, i) {
+			free(entry->value);
+		}
+		hashmap__free(type->members);
+	}
+
+	free(type);
+}
+
+struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path) {
+	struct btf_reloc_info *info;
+	struct btf *src_btf;
+	struct hashmap *ids_map;
+	struct hashmap *types;
+
+	info = calloc(1, sizeof(*info));
+	if (!info)
+		return ERR_PTR(-ENOMEM);
+
+	src_btf = btf__parse(targ_btf_path, NULL);
+	if (libbpf_get_error(src_btf)) {
+		bpf_reloc_info__free(info);
+		return (void *) src_btf;
+	}
+
+	info->src_btf = src_btf;
+
+	ids_map = hashmap__new(bpf_reloc_info_hash_fn, bpf_reloc_info_equal_fn, NULL);
+	if (IS_ERR(ids_map)) {
+		bpf_reloc_info__free(info);
+		return (void *) ids_map;
+	}
+
+	info->ids_map = ids_map;
+
+	types = hashmap__new(bpf_reloc_info_hash_fn, bpf_reloc_info_equal_fn, NULL);
+	if (IS_ERR(types)) {
+		bpf_reloc_info__free(info);
+		return (void *) types;
+	}
+
+	info->types = types;
+
+	return info;
+}
+
+void bpf_reloc_info__free(struct btf_reloc_info *info) {
+	struct hashmap_entry *entry;
+	int i;
+
+	if (!info)
+		return;
+
+	hashmap__free(info->ids_map);
+
+	if (!IS_ERR_OR_NULL(info->types)) {
+		hashmap__for_each_entry(info->types, entry, i) {
+			bpf_reloc_type_free(entry->value);
+		}
+		hashmap__free(info->types);
+	}
+
+	free(info);
+}
+
+/* Return id for type in new btf instance */
+static unsigned int btf_reloc_id_get(struct btf_reloc_info *info, unsigned int old) {
+	uintptr_t new = 0;
+
+	/* deal with BTF_KIND_VOID */
+	if (old == 0)
+		return 0;
+
+	if (!hashmap__find(info->ids_map, uint_as_hash_key(old), (void **)&new)) {
+		/* return id for void as it's possible that the ID we're looking for is
+		 * the type of a pointer that we're not adding.
+		 */
+		return 0;
+	}
+
+	return (unsigned int)(uintptr_t)new;
+}
+
+/* Add new id map to the list of mappings */
+static int btf_reloc_id_add(struct btf_reloc_info *info, unsigned int old, unsigned int new) {
+	return hashmap__add(info->ids_map, uint_as_hash_key(old), uint_as_hash_key(new));
+}
+
+/*
+ * Put type in the list. If the type already exists it's returned, otherwise a
+ * new one is created and added to the list. This is called recursively adding
+ * all the types that are needed for the current one.
+ */
+static struct btf_reloc_type *btf_reloc_put_type(struct btf *btf,
+						 struct btf_reloc_info *info,
+						 struct btf_type *btf_type,
+						 unsigned int id) {
+	struct btf_reloc_type *reloc_type, *tmp;
+	struct btf_array *array;
+	unsigned int child_id;
+	int err;
+
+	/* check if we already have this type */
+	if (hashmap__find(info->types, uint_as_hash_key(id), (void **) &reloc_type)) {
+		return reloc_type;
+	}
+
+	/* do nothing. void is implicit in BTF */
+	if (id == 0)
+		return NULL;
+
+	reloc_type = calloc(1, sizeof(*reloc_type));
+	if (!reloc_type)
+		return ERR_PTR(-ENOMEM);
+
+	reloc_type->type = btf_type;
+	reloc_type->id = id;
+
+	/* append this type to the relocation type's list before anything else */
+	err = hashmap__add(info->types, uint_as_hash_key(reloc_type->id), reloc_type);
+	if (err)
+		return ERR_PTR(err);
+
+	/* complex types might need further processing */
+	switch (btf_kind(reloc_type->type)) {
+	/* already processed */
+	case BTF_KIND_UNKN:
+	case BTF_KIND_INT:
+	case BTF_KIND_FLOAT:
+	/* processed by callee */
+	case BTF_KIND_STRUCT:
+	case BTF_KIND_UNION:
+	/* doesn't need resolution. If the data of the pointer is used
+	 * then it'll added by the caller in another relocation.
+	 */
+	case BTF_KIND_PTR:
+		break;
+	/* needs resolution */
+	case BTF_KIND_CONST:
+	case BTF_KIND_VOLATILE:
+	case BTF_KIND_TYPEDEF:
+		child_id = btf_type->type;
+		btf_type = (struct btf_type *) btf__type_by_id(btf, child_id);
+		 if (!btf_type)
+			return ERR_PTR(-EINVAL);
+
+		tmp = btf_reloc_put_type(btf, info, btf_type, child_id);
+		if (IS_ERR(tmp))
+			return tmp;
+		break;
+	/* needs resolution */
+	case BTF_KIND_ARRAY:
+		array = btf_array(reloc_type->type);
+
+		/* add type for array type */
+		btf_type = (struct btf_type *) btf__type_by_id(btf, array->type);
+		tmp = btf_reloc_put_type(btf, info, btf_type, array->type);
+		if (IS_ERR(tmp))
+			return tmp;
+
+		/* add type for array's index type */
+		btf_type = (struct btf_type *) btf__type_by_id(btf, array->index_type);
+		tmp = btf_reloc_put_type(btf, info, btf_type, array->index_type);
+		if (IS_ERR(tmp))
+			return tmp;
+
+		break;
+	/* tells if some other type needs to be handled */
+	default:
+		printf("unsupported relocation: %d\n", reloc_type->id);
+		return ERR_PTR(-EINVAL);
+	}
+
+	return reloc_type;
+}
+
+/* Return pointer to btf_reloc_type by id */
+static struct btf_reloc_type *btf_reloc_get_type(struct btf_reloc_info *info, int id) {
+	struct btf_reloc_type *type = NULL;
+
+	if (!hashmap__find(info->types, uint_as_hash_key(id), (void **)&type))
+		return ERR_PTR(-ENOENT);
+
+	return type;
+}
+
+static int bpf_reloc_type_add_member(struct btf_reloc_info *info,
+				     struct btf_reloc_type *reloc_type,
+				     struct btf_member *btf_member, int idx) {
+	int err;
+	struct btf_reloc_member *reloc_member;
+
+	/* create new members hashmap for this relocation type if needed */
+	if (reloc_type->members == NULL) {
+		struct hashmap *tmp = hashmap__new(bpf_reloc_info_hash_fn,
+						   bpf_reloc_info_equal_fn,
+						   NULL);
+		if (IS_ERR(tmp))
+			return PTR_ERR(tmp);
+
+		reloc_type->members = tmp;
+	}
+	/* add given btf_member as a member of the parent relocation_type's type */
+	reloc_member = calloc(1, sizeof(*reloc_member));
+	if (!reloc_member)
+		return -ENOMEM;
+	reloc_member->member = btf_member;
+	reloc_member->idx = idx;
+	/* add given btf_member as member to given relocation type */
+	err = hashmap__add(reloc_type->members, uint_as_hash_key(reloc_member->idx), reloc_member);
+	if (err) {
+		free(reloc_member);
+		if (err != -EEXIST)
+			return err;
+	}
+
 	return 0;
 }
 
-static int verbose_print(enum libbpf_print_level level, const char *format, va_list args)
-{
-	return vfprintf(stderr, format, args);
-}
+static int btf_reloc_info_gen_field(struct btf_reloc_info *info, struct bpf_core_spec_pub *targ_spec) {
+	struct btf *btf = (struct btf *) info->src_btf;
+	struct btf_reloc_type *reloc_type;
+	struct btf_member *btf_member;
+	struct btf_type *btf_type;
+	struct btf_array *array;
+	unsigned int id;
+	int idx, err;
 
-int generate_btf(const char *src_btf, const char *dst_btf, const char *objspaths[]) {
-	struct btf_reloc_info *reloc_info;
-	struct btf *btf_new;
-	int err;
+	btf_type = (struct btf_type *) btf__type_by_id(btf, targ_spec->root_type_id);
 
-	reloc_info = bpf_reloc_info__new(src_btf);
-	err = libbpf_get_error(reloc_info);
-	if (err) {
-		printf("failed to allocate info structure\n");
-		goto out;
-	}
+	/* create reloc type for root type */
+	reloc_type = btf_reloc_put_type(btf, info, btf_type, targ_spec->root_type_id);
+	if (IS_ERR(reloc_type))
+		return PTR_ERR(reloc_type);
 
-	for (int i = 0; objspaths[i] != NULL; i++) {
-		printf("processing %s object\n", objspaths[i]);
+	/* add types for complex types (arrays, unions, structures) */
+	for (int i = 1; i < targ_spec->raw_len; i++) {
 
-		struct bpf_object *obj = bpf_object__open(objspaths[i]);
-		err = libbpf_get_error(obj);
-		if (err) {
-			printf("error opening object\n");
-			goto out;
+		/* skip typedefs and mods. */
+		while (btf_is_mod(btf_type) || btf_is_typedef(btf_type)) {
+			id = btf_type->type;
+			reloc_type = btf_reloc_get_type(info, id);
+			if (IS_ERR(reloc_type))
+				return PTR_ERR(reloc_type);
+			btf_type = (struct btf_type *) btf__type_by_id(btf, id);
 		}
 
-		err = bpf_object__reloc_info_gen(reloc_info, obj);
-		if (err) {
-			bpf_object__close(obj);
-			printf("failed to generate btf info for object\n");
-			goto out;
-		}
+		switch (btf_kind(btf_type)) {
+		case BTF_KIND_STRUCT:
+		case BTF_KIND_UNION:
+			idx = targ_spec->raw_spec[i];
+			btf_member = btf_members(btf_type) + idx;
+			btf_type =  (struct btf_type *) btf__type_by_id(btf, btf_member->type);
 
-		bpf_object__close(obj);
-	}
-
-	btf_new = bpf_reloc_info__get_btf(reloc_info);
-	err = libbpf_get_error(btf_new);
-	if (err) {
-		printf("error generating btf\n");
-		goto out;
-	}
-
-	err = btf__save_to_file(btf_new, dst_btf);
-	if (err) {
-		printf("error saving btf file\n");
-		goto out;
-	}
-
-out:
-	if (!libbpf_get_error(btf_new))
-		btf__free(btf_new);
-	bpf_reloc_info__free(reloc_info);
-	return err;
-}
-
-int main(int argc, char **argv)
-{
-	struct dirent *dir;
-	int err;
-	DIR *d;
-
-	static const struct argp argp = {
-		.options = opts,
-		.parser = parse_arg,
-	};
-
-	static struct env env = {
-		.obj_index = 0,
-	};
-
-	err = argp_parse(&argp, argc, argv, 0, NULL, &env);
-	if (err)
-		return err;
-
-	/* Set up libbpf errors and debug info callback */
-	if (env.verbose) {
-		libbpf_set_print(verbose_print);
-	}
-
-	d = opendir(env.inputdir);
-	if (!d) {
-		printf("error opening input dir\n");
-		return -1;
-	}
-
-	while ((dir = readdir(d)) != NULL) {
-		char src_btf_path[PATH_MAX];
-		char dst_btf_path[PATH_MAX];
-
-		if (dir->d_type != DT_REG)
-			continue;
-
-		/* ignore non BTF files */
-		if (strncmp(dir->d_name + strlen(dir->d_name) - 4, ".btf", 4))
-			continue;
-
-		snprintf(src_btf_path, sizeof(src_btf_path), "%s/%s", env.inputdir, dir->d_name);
-		snprintf(dst_btf_path, sizeof(dst_btf_path), "%s/%s", env.outputdir, dir->d_name);
-
-		printf("generating btf from %s\n", src_btf_path);
-
-		err = generate_btf(src_btf_path, dst_btf_path, env.obj);
-		if (err) {
-			printf("failed to generate btf for %s\n", src_btf_path);
-			closedir(d);
+			/* add member to relocation type */
+			err = bpf_reloc_type_add_member(info, reloc_type, btf_member, idx);
+			if (err)
+				return err;
+			/* add relocation type */
+			reloc_type = btf_reloc_put_type(btf, info, btf_type, btf_member->type);
+			if (IS_ERR(reloc_type))
+				return PTR_ERR(reloc_type);
+			break;
+		case BTF_KIND_ARRAY:
+			array = btf_array(btf_type);
+			reloc_type = btf_reloc_get_type(info, array->type);
+			if (IS_ERR(reloc_type))
+				return PTR_ERR(reloc_type);
+			btf_type = (struct btf_type *) btf__type_by_id(btf, array->type);
+			break;
+		default:
+			//printf("spec type wasn't handled: %s\n", btf_kind_str(btf_type));
+			printf("spec type wasn't handled\n");
 			return 1;
 		}
 	}
 
-	closedir(d);
-
-	printf("done!\n");
 	return 0;
+}
+
+static int btf_reloc_info_gen_type(struct btf_reloc_info *info, struct bpf_core_spec_pub *targ_spec) {
+	printf("untreated type based relocation\n");
+	return -EOPNOTSUPP;
+}
+
+static int btf_reloc_info_gen_enumval(struct btf_reloc_info *info, struct bpf_core_spec_pub *targ_spec) {
+	printf("untreated enumval based relocation\n");
+	return -EOPNOTSUPP;
+}
+
+static int btf_reloc_info_gen(struct btf_reloc_info *info, struct bpf_core_relo_pub *res) {
+	if (core_relo_is_type_based(res->relo_kind))
+		return btf_reloc_info_gen_type(info, &res->targ_spec);
+
+	if (core_relo_is_enumval_based(res->relo_kind))
+		return btf_reloc_info_gen_enumval(info, &res->targ_spec);
+
+	if (core_relo_is_field_based(res->relo_kind))
+		return btf_reloc_info_gen_field(info, &res->targ_spec);
+
+	return -EINVAL;
+}
+
+int bpf_object__reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_object *obj) {
+	struct bpf_core_relo_pub *relos;
+	struct bpf_program *prog;
+	int err;
+
+	bpf_object__for_each_program(prog, obj) {
+		relos = (struct bpf_core_relo_pub *) bpf_program__core_relos(prog);
+		int n = bpf_program__core_relos_cnt(prog);
+		for (int i = 0; i < n; i++) {
+			if (relos[i].poison) {
+				printf("core reloc poisoned...\n");
+				continue;
+			}
+
+			err = btf_reloc_info_gen(reloc_info, &relos[i]);
+			if (err)
+				goto out;
+		}
+	}
+
+out:
+	return err;
+}
+
+struct btf *bpf_reloc_info__get_btf(struct btf_reloc_info *info) {
+	struct hashmap_entry *entry;
+	struct btf *btf_new;
+	int err, i;
+
+	btf_new = btf__new_empty();
+	if (IS_ERR(btf_new)) {
+		printf("failed to allocate btf structure\n");
+		return btf_new;
+	}
+
+	/* first pass: add all types and add their new ids to the ids map */
+	hashmap__for_each_entry(info->types, entry, i) {
+		struct btf_reloc_type *reloc_type = entry->value;
+		struct btf_type *btf_type = reloc_type->type;
+		int new_id;
+
+		/* add members for struct and union */
+		if (btf_is_struct(btf_type) || btf_is_union(btf_type)) {
+			struct hashmap_entry *member_entry;
+			struct btf_type *btf_type_cpy;
+			int nmembers, bkt, index;
+			size_t new_size;
+
+			nmembers = reloc_type->members ? hashmap__size(reloc_type->members) : 0;
+			new_size = sizeof(struct btf_type) + nmembers * sizeof(struct btf_member);
+
+			btf_type_cpy = malloc(new_size);
+			if (!btf_type_cpy) {
+				err = -ENOMEM;
+				goto out;
+			}
+
+			/* copy header */
+			memcpy(btf_type_cpy, btf_type, sizeof(*btf_type_cpy));
+
+			/* copy only members that are needed */
+			index = 0;
+			if (nmembers > 0) {
+				hashmap__for_each_entry(reloc_type->members, member_entry, bkt) {
+					struct btf_reloc_member *reloc_member;
+					struct btf_member *btf_member;
+
+					reloc_member = member_entry->value;
+					btf_member = btf_members(btf_type) + reloc_member->idx;
+
+					memcpy(btf_members(btf_type_cpy) + index, btf_member, sizeof(struct btf_member));
+
+					index++;
+				}
+			}
+
+			/* set new vlen */
+			btf_type_cpy->info = btf_type_info(btf_kind(btf_type_cpy), nmembers, btf_kflag(btf_type_cpy));
+
+			err = btf__add_type(btf_new, info->src_btf, btf_type_cpy);
+			free(btf_type_cpy);
+		} else {
+			err = btf__add_type(btf_new, info->src_btf, btf_type);
+		}
+
+		if (err < 0)
+			goto out;
+
+		new_id = err;
+
+		/* add ID mapping */
+		err = btf_reloc_id_add(info, reloc_type->id, new_id);
+		if (err)
+			goto out;
+	}
+
+	/* second pass: fix up type ids */
+	for (int i = 0; i <= btf__get_nr_types(btf_new); i++) {
+		struct btf_member *btf_member;
+		struct btf_type *btf_type;
+		struct btf_param *params;
+		struct btf_array *array;
+
+		btf_type = (struct btf_type *) btf__type_by_id(btf_new, i);
+
+		switch (btf_kind(btf_type)) {
+		case BTF_KIND_STRUCT:
+		case BTF_KIND_UNION:
+			for (int i = 0; i < btf_vlen(btf_type); i++) {
+				btf_member = btf_members(btf_type) + i;
+				btf_member->type = btf_reloc_id_get(info, btf_member->type);
+			}
+			break;
+		case BTF_KIND_PTR:
+		case BTF_KIND_TYPEDEF:
+		case BTF_KIND_VOLATILE:
+		case BTF_KIND_CONST:
+		case BTF_KIND_RESTRICT:
+		case BTF_KIND_FUNC:
+		case BTF_KIND_VAR:
+			btf_type->type = btf_reloc_id_get(info, btf_type->type);
+			break;
+		case BTF_KIND_ARRAY:
+			array = btf_array(btf_type);
+			array->index_type = btf_reloc_id_get(info, array->index_type);
+			array->type = btf_reloc_id_get(info, array->type);
+			break;
+		case BTF_KIND_FUNC_PROTO:
+			btf_type->type = btf_reloc_id_get(info, btf_type->type);
+			params = btf_params(btf_type);
+			for (int i = 0; i < btf_vlen(btf_type); i++) {
+				params[i].type = btf_reloc_id_get(info, params[i].type);
+			}
+			break;
+		}
+	}
+
+	/* deduplicate generated BTF */
+	struct btf_dedup_opts dedup_opts = {};
+	err = btf__dedup(btf_new, NULL, &dedup_opts);
+	if (err) {
+		printf("error calling btf__dedup()\n");
+		goto out;
+	}
+
+	return btf_new;
+
+out:
+	btf__free(btf_new);
+	return ERR_PTR(err);
 }

--- a/btfgen.c
+++ b/btfgen.c
@@ -419,6 +419,7 @@ int btfgen_obj_reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_obje
 	struct bpf_core_relo_result *relos;
 	struct bpf_program *prog;
 	int err;
+	bool poisoned = false;
 
 	bpf_object__for_each_program(prog, obj) {
 		relos = (struct bpf_core_relo_result *) bpf_program__core_relos(prog);
@@ -426,7 +427,7 @@ int btfgen_obj_reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_obje
 
 		for (int i = 0; i < n; i++) {
 			if (relos[i].poison) {
-				printf("core reloc poisoned...\n");
+				poisoned = true;
 				continue;
 			}
 
@@ -437,6 +438,9 @@ int btfgen_obj_reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_obje
 	}
 
 out:
+	if (poisoned)
+		printf("warning: poisoned btf for this target\n");
+
 	return err;
 }
 

--- a/btfgen.c
+++ b/btfgen.c
@@ -439,7 +439,7 @@ int btfgen_obj_reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_obje
 
 out:
 	if (poisoned)
-		printf("warning: poisoned btf for this target\n");
+		return -ENOEXEC;
 
 	return err;
 }

--- a/btfgen.c
+++ b/btfgen.c
@@ -120,7 +120,7 @@ void bpf_reloc_type_free(struct btf_reloc_type *type) {
 	free(type);
 }
 
-struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path) {
+struct btf_reloc_info *btfgen_reloc_info_new(const char *targ_btf_path) {
 	struct btf_reloc_info *info;
 	struct btf *src_btf;
 	struct hashmap *ids_map;
@@ -132,7 +132,7 @@ struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path) {
 
 	src_btf = btf__parse(targ_btf_path, NULL);
 	if (libbpf_get_error(src_btf)) {
-		bpf_reloc_info__free(info);
+		btfgen_reloc_info_free(info);
 		return (void *) src_btf;
 	}
 
@@ -140,7 +140,7 @@ struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path) {
 
 	ids_map = hashmap__new(bpf_reloc_info_hash_fn, bpf_reloc_info_equal_fn, NULL);
 	if (IS_ERR(ids_map)) {
-		bpf_reloc_info__free(info);
+		btfgen_reloc_info_free(info);
 		return (void *) ids_map;
 	}
 
@@ -148,7 +148,7 @@ struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path) {
 
 	types = hashmap__new(bpf_reloc_info_hash_fn, bpf_reloc_info_equal_fn, NULL);
 	if (IS_ERR(types)) {
-		bpf_reloc_info__free(info);
+		btfgen_reloc_info_free(info);
 		return (void *) types;
 	}
 
@@ -157,7 +157,7 @@ struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path) {
 	return info;
 }
 
-void bpf_reloc_info__free(struct btf_reloc_info *info) {
+void btfgen_reloc_info_free(struct btf_reloc_info *info) {
 	struct hashmap_entry *entry;
 	int i;
 
@@ -415,7 +415,7 @@ static int btf_reloc_info_gen(struct btf_reloc_info *info, struct bpf_core_relo_
 	return -EINVAL;
 }
 
-int bpf_object__reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_object *obj) {
+int btfgen_obj_reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_object *obj) {
 	struct bpf_core_relo_result *relos;
 	struct bpf_program *prog;
 	int err;
@@ -440,7 +440,7 @@ out:
 	return err;
 }
 
-struct btf *bpf_reloc_info__get_btf(struct btf_reloc_info *info) {
+struct btf *btfgen_reloc_info_get_btf(struct btf_reloc_info *info) {
 	struct hashmap_entry *entry;
 	struct btf *btf_new;
 	int err, i;

--- a/btfgen.h
+++ b/btfgen.h
@@ -16,7 +16,7 @@
 
 struct bpf_reloc_info;
 
-struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path);
-void bpf_reloc_info__free(struct btf_reloc_info *info);
-int bpf_object__reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_object *obj);
-struct btf *bpf_reloc_info__get_btf(struct btf_reloc_info *info);
+struct btf_reloc_info *btfgen_reloc_info_new(const char *targ_btf_path);
+void btfgen_reloc_info_free(struct btf_reloc_info *info);
+int btfgen_obj_reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_object *obj);
+struct btf *btfgen_reloc_info_get_btf(struct btf_reloc_info *info);

--- a/btfgen.h
+++ b/btfgen.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bpf/libbpf.h>
+
+struct bpf_reloc_info;
+
+struct btf_reloc_info *bpf_reloc_info__new(const char *targ_btf_path);
+void bpf_reloc_info__free(struct btf_reloc_info *info);
+int bpf_object__reloc_info_gen(struct btf_reloc_info *reloc_info, struct bpf_object *obj);
+struct btf *bpf_reloc_info__get_btf(struct btf_reloc_info *info);

--- a/hashmap.h
+++ b/hashmap.h
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
+/*
+ * Generic non-thread safe hash map implementation.
+ *
+ * Copyright (c) 2019 Facebook
+ */
+#ifndef __LIBBPF_HASHMAP_H
+#define __LIBBPF_HASHMAP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <limits.h>
+
+static inline size_t hash_bits(size_t h, int bits)
+{
+	/* shuffle bits and return requested number of upper bits */
+	if (bits == 0)
+		return 0;
+
+#if (__SIZEOF_SIZE_T__ == __SIZEOF_LONG_LONG__)
+	/* LP64 case */
+	return (h * 11400714819323198485llu) >> (__SIZEOF_LONG_LONG__ * 8 - bits);
+#elif (__SIZEOF_SIZE_T__ <= __SIZEOF_LONG__)
+	return (h * 2654435769lu) >> (__SIZEOF_LONG__ * 8 - bits);
+#else
+#	error "Unsupported size_t size"
+#endif
+}
+
+/* generic C-string hashing function */
+static inline size_t str_hash(const char *s)
+{
+	size_t h = 0;
+
+	while (*s) {
+		h = h * 31 + *s;
+		s++;
+	}
+	return h;
+}
+
+typedef size_t (*hashmap_hash_fn)(const void *key, void *ctx);
+typedef bool (*hashmap_equal_fn)(const void *key1, const void *key2, void *ctx);
+
+struct hashmap_entry {
+	const void *key;
+	void *value;
+	struct hashmap_entry *next;
+};
+
+struct hashmap {
+	hashmap_hash_fn hash_fn;
+	hashmap_equal_fn equal_fn;
+	void *ctx;
+
+	struct hashmap_entry **buckets;
+	size_t cap;
+	size_t cap_bits;
+	size_t sz;
+};
+
+#define HASHMAP_INIT(hash_fn, equal_fn, ctx) {	\
+	.hash_fn = (hash_fn),			\
+	.equal_fn = (equal_fn),			\
+	.ctx = (ctx),				\
+	.buckets = NULL,			\
+	.cap = 0,				\
+	.cap_bits = 0,				\
+	.sz = 0,				\
+}
+
+void hashmap__init(struct hashmap *map, hashmap_hash_fn hash_fn,
+		   hashmap_equal_fn equal_fn, void *ctx);
+struct hashmap *hashmap__new(hashmap_hash_fn hash_fn,
+			     hashmap_equal_fn equal_fn,
+			     void *ctx);
+void hashmap__clear(struct hashmap *map);
+void hashmap__free(struct hashmap *map);
+
+size_t hashmap__size(const struct hashmap *map);
+size_t hashmap__capacity(const struct hashmap *map);
+
+/*
+ * Hashmap insertion strategy:
+ * - HASHMAP_ADD - only add key/value if key doesn't exist yet;
+ * - HASHMAP_SET - add key/value pair if key doesn't exist yet; otherwise,
+ *   update value;
+ * - HASHMAP_UPDATE - update value, if key already exists; otherwise, do
+ *   nothing and return -ENOENT;
+ * - HASHMAP_APPEND - always add key/value pair, even if key already exists.
+ *   This turns hashmap into a multimap by allowing multiple values to be
+ *   associated with the same key. Most useful read API for such hashmap is
+ *   hashmap__for_each_key_entry() iteration. If hashmap__find() is still
+ *   used, it will return last inserted key/value entry (first in a bucket
+ *   chain).
+ */
+enum hashmap_insert_strategy {
+	HASHMAP_ADD,
+	HASHMAP_SET,
+	HASHMAP_UPDATE,
+	HASHMAP_APPEND,
+};
+
+/*
+ * hashmap__insert() adds key/value entry w/ various semantics, depending on
+ * provided strategy value. If a given key/value pair replaced already
+ * existing key/value pair, both old key and old value will be returned
+ * through old_key and old_value to allow calling code do proper memory
+ * management.
+ */
+int hashmap__insert(struct hashmap *map, const void *key, void *value,
+		    enum hashmap_insert_strategy strategy,
+		    const void **old_key, void **old_value);
+
+static inline int hashmap__add(struct hashmap *map,
+			       const void *key, void *value)
+{
+	return hashmap__insert(map, key, value, HASHMAP_ADD, NULL, NULL);
+}
+
+static inline int hashmap__set(struct hashmap *map,
+			       const void *key, void *value,
+			       const void **old_key, void **old_value)
+{
+	return hashmap__insert(map, key, value, HASHMAP_SET,
+			       old_key, old_value);
+}
+
+static inline int hashmap__update(struct hashmap *map,
+				  const void *key, void *value,
+				  const void **old_key, void **old_value)
+{
+	return hashmap__insert(map, key, value, HASHMAP_UPDATE,
+			       old_key, old_value);
+}
+
+static inline int hashmap__append(struct hashmap *map,
+				  const void *key, void *value)
+{
+	return hashmap__insert(map, key, value, HASHMAP_APPEND, NULL, NULL);
+}
+
+bool hashmap__delete(struct hashmap *map, const void *key,
+		     const void **old_key, void **old_value);
+
+bool hashmap__find(const struct hashmap *map, const void *key, void **value);
+
+/*
+ * hashmap__for_each_entry - iterate over all entries in hashmap
+ * @map: hashmap to iterate
+ * @cur: struct hashmap_entry * used as a loop cursor
+ * @bkt: integer used as a bucket loop cursor
+ */
+#define hashmap__for_each_entry(map, cur, bkt)				    \
+	for (bkt = 0; bkt < map->cap; bkt++)				    \
+		for (cur = map->buckets[bkt]; cur; cur = cur->next)
+
+/*
+ * hashmap__for_each_entry_safe - iterate over all entries in hashmap, safe
+ * against removals
+ * @map: hashmap to iterate
+ * @cur: struct hashmap_entry * used as a loop cursor
+ * @tmp: struct hashmap_entry * used as a temporary next cursor storage
+ * @bkt: integer used as a bucket loop cursor
+ */
+#define hashmap__for_each_entry_safe(map, cur, tmp, bkt)		    \
+	for (bkt = 0; bkt < map->cap; bkt++)				    \
+		for (cur = map->buckets[bkt];				    \
+		     cur && ({tmp = cur->next; true; });		    \
+		     cur = tmp)
+
+/*
+ * hashmap__for_each_key_entry - iterate over entries associated with given key
+ * @map: hashmap to iterate
+ * @cur: struct hashmap_entry * used as a loop cursor
+ * @key: key to iterate entries for
+ */
+#define hashmap__for_each_key_entry(map, cur, _key)			    \
+	for (cur = map->buckets						    \
+		     ? map->buckets[hash_bits(map->hash_fn((_key), map->ctx), map->cap_bits)] \
+		     : NULL;						    \
+	     cur;							    \
+	     cur = cur->next)						    \
+		if (map->equal_fn(cur->key, (_key), map->ctx))
+
+#define hashmap__for_each_key_entry_safe(map, cur, tmp, _key)		    \
+	for (cur = map->buckets						    \
+		     ? map->buckets[hash_bits(map->hash_fn((_key), map->ctx), map->cap_bits)] \
+		     : NULL;						    \
+	     cur && ({ tmp = cur->next; true; });			    \
+	     cur = tmp)							    \
+		if (map->equal_fn(cur->key, (_key), map->ctx))
+
+#endif /* __LIBBPF_HASHMAP_H */

--- a/main.c
+++ b/main.c
@@ -199,11 +199,6 @@ int main(int argc, char **argv)
 	if (err)
 		return err;
 
-	if (getuid() != 0) {
-		printf("ERR : you need root privileges to run this tool\n");
-		return 1;
-	}
-
 	if (env.verbose)
 		libbpf_set_print(verbose_print);
 

--- a/main.c
+++ b/main.c
@@ -84,7 +84,7 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 		.record_core_relos = true,
 	};
 
-	reloc_info = bpf_reloc_info__new(src_btf);
+	reloc_info = btfgen_reloc_info_new(src_btf);
 	err = libbpf_get_error(reloc_info);
 	if (err) {
 		printf("failed to allocate info structure\n");
@@ -105,7 +105,7 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 			goto out;
 		}
 
-		err = bpf_object__reloc_info_gen(reloc_info, obj);
+		err = btfgen_obj_reloc_info_gen(reloc_info, obj);
 		if (err) {
 			goto out;
 		}
@@ -113,7 +113,7 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 		bpf_object__close(obj);
 	}
 
-	btf_new = bpf_reloc_info__get_btf(reloc_info);
+	btf_new = btfgen_reloc_info_get_btf(reloc_info);
 	err = libbpf_get_error(btf_new);
 	if (err) {
 		printf("error generating btf\n");
@@ -129,7 +129,7 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 out:
 	if (!libbpf_get_error(btf_new))
 		btf__free(btf_new);
-	bpf_reloc_info__free(reloc_info);
+	btfgen_reloc_info_free(reloc_info);
 	return err;
 }
 

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@
 #include <linux/limits.h>
 #include <argp.h>
 #include <dirent.h>
+#include <stdbool.h>
 
 #include <bpf/libbpf.h>
 #include <bpf/btf.h>
@@ -80,6 +81,7 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 	struct bpf_object_open_opts ops = {
 		.sz = sizeof(ops),
 		.btf_custom_path = src_btf,
+		.record_core_relos = true,
 	};
 
 	reloc_info = bpf_reloc_info__new(src_btf);
@@ -98,15 +100,10 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 			goto out;
 		}
 
-        struct bpf_object_prepare_attr attr = {
-            .obj = obj,
-            .record_core_relos = true,
-        };
-
-        err = bpf_object__prepare_xattr(&attr);
-        if (err) {
-            goto out;
-        }
+		err = bpf_object__prepare(obj);
+		if (err) {
+			goto out;
+		}
 
 		err = bpf_object__reloc_info_gen(reloc_info, obj);
 		if (err) {

--- a/main.c
+++ b/main.c
@@ -99,6 +99,10 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case ARGP_KEY_END:
 		if (env->output == NULL || env->input == NULL || env->obj_index == 0)
 			argp_usage(state);
+		if (env->outfile < 0 || env->infile < 0) {
+			printf("ERR : could not stat given argument\n");
+			argp_usage(state);
+		}
 		break;
 	default:
 		return ARGP_ERR_UNKNOWN;
@@ -210,7 +214,6 @@ int main(int argc, char **argv)
 		if (env.outfile) {
 			err = generate_btf(env.input, env.output, env.obj);
 			generate_err(env.output);
-
 		} else {
 			snprintf(dst_btf_path, sizeof(dst_btf_path), "%s/%s", env.output, basename(strdup(env.input)));
 			err = generate_btf(env.input, dst_btf_path, env.obj);

--- a/main.c
+++ b/main.c
@@ -1,0 +1,196 @@
+// Copyright (c) Microsoft Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <argp.h>
+#include <dirent.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/btf.h>
+
+#include "btfgen.h"
+
+#define OBJ_KEY 260
+#define MAX_OBJECTS 128
+
+struct env {
+	const char *outputdir;
+	const char *inputdir;
+	const char *obj[MAX_OBJECTS];
+	int obj_index;
+	bool verbose;
+};
+
+static const struct argp_option opts[] = {
+	{ "verbose", 'v', NULL, 0, "display libbpf debug messages" },
+	{ "outputdir", 'o', "outputdir", 0, "dir to output the result BTF files" },
+	{ "inputdir", 'i', "inputdir", 0, "dir with source BTF files to use" },
+	{ "object", OBJ_KEY,  "object", 0, "path of object file to generate BTFs for" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	struct env *env = state->input;
+	switch (key) {
+	case 'v':
+		env->verbose = true;
+		break;
+	case 'o':
+		env->outputdir = arg;
+		break;
+	case 'i':
+		env->inputdir = arg;
+		break;
+	case OBJ_KEY:
+		env->obj[env->obj_index++] = arg;
+		break;
+	case ARGP_KEY_END:
+		if (env->outputdir == NULL || env->inputdir == NULL || env->obj_index == 0)
+			argp_usage(state);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int verbose_print(enum libbpf_print_level level, const char *format, va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+static int generate_btf(const char *src_btf, const char *dst_btf, const char *objspaths[]) {
+	struct btf_reloc_info *reloc_info;
+	struct bpf_object *obj;
+	struct btf *btf_new;
+	int err;
+
+	struct bpf_object_open_opts ops = {
+		.sz = sizeof(ops),
+		.btf_custom_path = src_btf,
+	};
+
+	reloc_info = bpf_reloc_info__new(src_btf);
+	err = libbpf_get_error(reloc_info);
+	if (err) {
+		printf("failed to allocate info structure\n");
+		goto out;
+	}
+
+	for (int i = 0; objspaths[i] != NULL; i++) {
+		printf("processing %s object\n", objspaths[i]);
+		obj = bpf_object__open_file(objspaths[i], &ops);
+		err = libbpf_get_error(obj);
+		if (err) {
+			printf("error opening object\n");
+			goto out;
+		}
+
+        struct bpf_object_prepare_attr attr = {
+            .obj = obj,
+            .record_core_relos = true,
+        };
+
+        err = bpf_object__prepare_xattr(&attr);
+        if (err) {
+            goto out;
+        }
+
+		err = bpf_object__reloc_info_gen(reloc_info, obj);
+		if (err) {
+			goto out;
+		}
+
+		bpf_object__close(obj);
+	}
+
+	btf_new = bpf_reloc_info__get_btf(reloc_info);
+	err = libbpf_get_error(btf_new);
+	if (err) {
+		printf("error generating btf\n");
+		goto out;
+	}
+
+	err = btf__save_to_file(btf_new, dst_btf);
+	if (err) {
+		printf("error saving btf file\n");
+		goto out;
+	}
+
+out:
+	if (!libbpf_get_error(btf_new))
+		btf__free(btf_new);
+	bpf_reloc_info__free(reloc_info);
+	return err;
+}
+
+int main(int argc, char **argv)
+{
+	struct dirent *dir;
+	int err;
+	DIR *d;
+
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+	};
+
+	static struct env env = {
+		.obj_index = 0,
+	};
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, &env);
+	if (err)
+		return err;
+
+	/* Set up libbpf errors and debug info callback */
+	if (env.verbose) {
+		libbpf_set_print(verbose_print);
+	}
+
+	d = opendir(env.inputdir);
+	if (!d) {
+		printf("error opening input dir\n");
+		return -1;
+	}
+
+	while ((dir = readdir(d)) != NULL) {
+		char src_btf_path[PATH_MAX];
+		char dst_btf_path[PATH_MAX];
+
+		if (dir->d_type != DT_REG)
+			continue;
+
+		/* ignore non BTF files */
+		if (strncmp(dir->d_name + strlen(dir->d_name) - 4, ".btf", 4))
+			continue;
+
+		snprintf(src_btf_path, sizeof(src_btf_path), "%s/%s", env.inputdir, dir->d_name);
+		snprintf(dst_btf_path, sizeof(dst_btf_path), "%s/%s", env.outputdir, dir->d_name);
+
+		printf("generating btf from %s\n", src_btf_path);
+
+		err = generate_btf(src_btf_path, dst_btf_path, env.obj);
+		if (err) {
+			printf("failed to generate btf for %s\n", src_btf_path);
+			closedir(d);
+			return 1;
+		}
+	}
+
+	closedir(d);
+
+	printf("done!\n");
+	return 0;
+}

--- a/stolen.h
+++ b/stolen.h
@@ -1,0 +1,28 @@
+#define MAX_ERRNO       4095
+
+#define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
+
+static inline void * ERR_PTR(long error_)
+{
+	return (void *) error_;
+}
+
+static inline long PTR_ERR(const void *ptr)
+{
+	return (long) ptr;
+}
+
+static inline bool IS_ERR(const void *ptr)
+{
+	return IS_ERR_VALUE((unsigned long)ptr);
+}
+
+static inline bool IS_ERR_OR_NULL(const void *ptr)
+{
+	return (!ptr) || IS_ERR_VALUE((unsigned long)ptr);
+}
+
+static inline long PTR_ERR_OR_ZERO(const void *ptr)
+{
+	return IS_ERR(ptr) ? PTR_ERR(ptr) : 0;
+}


### PR DESCRIPTION
commit 4e88bb5 (HEAD -> devel, rafaeldtinoco/devel, split-libbpf-api)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sat Nov 13 00:45:43 2021

    btfgen: rename btfgen functions

    btfgen functions aren't part of libbpf any longer, rename them to
    btfgen_XXX so we can better distinguish external (to libbpf) calls.

commit 53ce600
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sat Nov 13 00:28:11 2021

    btfgen: change struct names according to latest libbpf patches