### PR TITLE
Use btf_custom opt in bpf_object_open_opts

### DIFF
--- a/btfgen.c
+++ b/btfgen.c
@@ -82,13 +82,6 @@ struct btf_reloc_type {
 	struct hashmap *members;
 };
 
-struct btf_reloc_info {
-	struct hashmap *types;
-	struct hashmap *ids_map;
-
-	struct btf *src_btf;
-};
-
 static size_t bpf_reloc_info_hash_fn(const void *key, void *ctx)
 {
 	return (size_t)key;

--- a/btfgen.h
+++ b/btfgen.h
@@ -14,7 +14,14 @@
 
 #include <bpf/libbpf.h>
 
-struct bpf_reloc_info;
+struct hashmap;
+
+struct btf_reloc_info {
+	struct hashmap *types;
+	struct hashmap *ids_map;
+
+	struct btf *src_btf;
+};
 
 struct btf_reloc_info *btfgen_reloc_info_new(const char *targ_btf_path);
 void btfgen_reloc_info_free(struct btf_reloc_info *info);

--- a/main.c
+++ b/main.c
@@ -122,18 +122,18 @@ static int generate_btf(const char *src_btf, const char *dst_btf, const char *ob
 	int err;
 	bool poisoned = false;
 
-	struct bpf_object_open_opts ops = {
-		.sz = sizeof(ops),
-		.btf_custom_path = src_btf,
-		.record_core_relos = true,
-	};
-
 	reloc_info = btfgen_reloc_info_new(src_btf);
 	err = libbpf_get_error(reloc_info);
 	if (err) {
 		printf("ERR : failed to allocate info structure\n");
 		goto out;
 	}
+
+	struct bpf_object_open_opts ops = {
+		.sz = sizeof(ops),
+		.btf_custom = reloc_info->src_btf,
+		.record_core_relos = true,
+	};
 
 	for (int i = 0; objspaths[i] != NULL; i++) {
 		printf("OBJ : %s\n", objspaths[i]);


### PR DESCRIPTION
Use btf_custom to avoid deferencing invalid pointers when running the
algorithm to generate the BTF file.
