### PR TITLE
btfgen: free src_btf when freeing reloc_info

### DIFF
--- a/btfgen.c
+++ b/btfgen.c
@@ -173,6 +173,7 @@ void btfgen_reloc_info_free(struct btf_reloc_info *info) {
 		hashmap__free(info->types);
 	}
 
+	btf__free(info->src_btf);
 	free(info);
 }
 


### PR DESCRIPTION
# Fix memory leak in `btfgen_reloc_info_free`

## How to use

Usage didn't change.

## Testing done

Executed memcheck and massif against the api exposed by btfgen.

These are the results I got

<img width="1781" alt="image" src="https://user-images.githubusercontent.com/3083633/143438840-3eab702f-e6cf-49bf-b4f7-09af58fb40c8.png">



With this patch

<img width="1783" alt="image" src="https://user-images.githubusercontent.com/3083633/143438480-5a221d6f-74f1-4e5b-954c-a7563eb45c55.png">


